### PR TITLE
Groups#newのエラー対処

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -29,18 +29,13 @@ class GroupsController < ApplicationController
     @group = current_user.groups.new(group_params)
 
     if @group.maximum_amount <= Food.where(id: @group.food_ids).sum(:price)
-
       @group.high_calorie(@group.maximum_amount, @group.food_ids)
-
-    end
-    group_params[:food_ids].each do |groupg|
-      foods = @group.foods.pluck(:food_id)
-      unless foods.include?(groupg.to_i)
-        food = SelectFood.new(food_id: groupg)
-        food.group_id = @group.id
-      end
     end
     if @group.save
+      group_params[:food_ids].each do |food_id|
+        select_food = @group.select_foods.find_or_initialize_by(food_id: food_id)
+        select_food.save
+      end
       redirect_to group_path(@group)
     else
       render :new

--- a/app/javascript/controllers/newgroups_controller.js
+++ b/app/javascript/controllers/newgroups_controller.js
@@ -5,9 +5,9 @@ export default class extends Controller {
   static targets = [
     "group_name",
     "maximum_amount",
-    "checkbox",
     "error_group_name",
     "error_maximum_amount",
+    "submit"
   ]
 
   group_nameValidation() {
@@ -35,6 +35,20 @@ export default class extends Controller {
     }else {
       maximum_amountInput.style.border = "2px solid lightgreen"
       maximum_amountError.textContent = ""
+    }
+  }
+
+  validSubmit() {
+    const submitBtn = this.submitTarget
+
+    if((this.group_nameTarget.value !== "") && (this.maximum_amountTarget.value !== "")){
+      if((this.error_group_nameTarget.textContent === "") && (this.error_maximum_amountTarget.textContent === "")){
+        submitBtn.disabled = false
+      }else{
+        submitBtn.disabled = true
+      }
+    }else{
+      submitBtn.disabled = true
     }
   }
 }

--- a/app/models/group.rb
+++ b/app/models/group.rb
@@ -5,7 +5,7 @@ class Group < ApplicationRecord
   has_many :comments, dependent: :destroy
 
   validates :group_name, presence: true
-  validates :maximum_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 30000 }
+  validates :maximum_amount, presence: true, numericality: { only_integer: true, greater_than_or_equal_to: 0, less_than_or_equal_to: 30_000 }
   validates :publish, inclusion: { in: [true, false] }
 
   # 長すぎるとrubocopに指摘された[<17, 61, 10> 64.11/25]

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -25,7 +25,7 @@
 
 
   <div class="actions">
-    <%= form.submit class:"btn btn-primary", data: { newgroups_target: "submit" } %>
+    <%= form.submit class:"btn btn-primary", disabled: true, data: { newgroups_target: "submit" } %>
   </div>
 
   <div>

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -1,6 +1,6 @@
 <%= render 'foods/modal' %>
 <div class="form-control">
-  <%= form_with(model: @group, local: true, group_id: @group.id, data: { controller: "newgroups checkbox" }) do |form| %>
+  <%= form_with(model: @group, local: true, group_id: @group.id, data: { controller: "newgroups checkbox", action: "input->newgroups#validSubmit" } ) do |form| %>
   <div class="input-group-md">
     <%= form.label :group_name %>
     <%= form.text_field :group_name, class: "input input-bordered w-full max-w-xs", data: { newgroups_target: "group_name", action: "input->newgroups#group_nameValidation" } %>
@@ -25,7 +25,7 @@
 
 
   <div class="actions">
-    <%= form.submit class:"btn btn-primary" %>
+    <%= form.submit class:"btn btn-primary", data: { newgroups_target: "submit" } %>
   </div>
 
   <div>


### PR DESCRIPTION
## 概要

- groupsのnewアクションにてgroup_nameを入れなかった場合にエラーが出るので修正を行う。

## 確認方法

1. stimulusコントローラーを作成
2. stimulusで名前を入力しないとボタンが押せないように変更

## チェック

- [x] rubocopをパスした
- [x] specをパスした