### PR TITLE
[Fix]groupsのページネーションによるバグの修正

### DIFF
--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -19,9 +19,9 @@ class GroupsController < ApplicationController
     @tags = Food.tags_on(:tags)
     @group = Group.new
     if params[:tag_name].present?
-      @foods = Food.tagged_with("#{params[:tag_name]}").includes(%i[taggings user groups]).order(created_at: :desc).references(:all).page(params[:page])
+      @foods = Food.tagged_with("#{params[:tag_name]}").includes(%i[taggings user groups]).order(created_at: :desc).references(:all)
     else
-      @foods = Food.includes(%i[taggings user groups]).references(:all).order(created_at: :desc).page(params[:page])
+      @foods = Food.includes(%i[taggings user groups]).references(:all).order(created_at: :desc)
     end
   end
 


### PR DESCRIPTION
## 概要

- groups#newにて@foodsにページネーションがされており,20件しか表示されていなかったため修正を行った。

## 確認方法

1. groups#newで@foodsが全件取得できていること

## チェック

- [x] rubocopをパスした
- [x] specをパスした