### PR TITLE
[Fix]csvファイルとそれに伴うfood_nameの文字数制限

### DIFF
--- a/app/models/food.rb
+++ b/app/models/food.rb
@@ -8,7 +8,7 @@ class Food < ApplicationRecord
 
   acts_as_taggable
 
-  validates :food_name, presence: true, length: { maximum: 20 }
+  validates :food_name, presence: true, length: { maximum: 30 }
   validates :calorie, presence: true
   validates :price, presence: true
   validates :protein, numericality: { allow_nil: true, greater_than_or_equal_to: 0 }

--- a/app/views/groups/new.html.erb
+++ b/app/views/groups/new.html.erb
@@ -50,7 +50,7 @@
 
   <div>
     <div class="not-prose grid grid-cols-1 gap-x-6 gap-y-12 sm:grid-cols-2 lg:grid-cols-3">
-      <%= form.collection_check_boxes(:food_ids, @foods, :id, :food_name) do |food| %>
+      <%= form.collection_check_boxes(:food_ids, @foods, :id, :food_name, include_hidden: false) do |food| %>
       <div class="card w-96 bg-base-100 shadow-xl">
         <div class="card-body">
           <%= food.label( class: "check_box", data: { controller: "checkbox" }) { food.check_box(checked: true, class:"form-tick checkbox checkbox-secondary") } %>
@@ -74,7 +74,7 @@
             <% end %>
             
           <div>
-            <%= food.object.calorie%>kcal<br>
+            <%= food.object.calorie %>kcal<br>
             <%= food.object.price %>円
           </div>
           <div class="p-8">

--- a/db/onigiri.csv
+++ b/db/onigiri.csv
@@ -10,34 +10,34 @@ Id,food_name,Price,Image,tag,calorie,protein,lipid,sugar,dietary_fiber,table_sal
 8,"金しゃり 塩にぎりセット",333,"https://www.lawson.co.jp/recommend/original/detail/img/l697433.png","おにぎり,ローソン",364,10.3,4.2,70.5,1.6,3.24
 9,"手巻おにぎり 熟成紀州南高梅",125,"https://www.lawson.co.jp/recommend/original/detail/img/l668245.png","おにぎり,ローソン",169,3.6,0.8,36.4,1.0,1.87
 10,"手巻おにぎり 追い鰹製法おかか",116,"https://www.lawson.co.jp/recommend/original/detail/img/l650862.png","おにぎり,ローソン",179,4.5,1.4,36.5,1.1,1.11
-11,手巻おにぎり 北海道産日高昆布,120,"https://www.lawson.co.jp/recommend/original/detail/img/l650861.png","おにぎり,ローソン",176,3.6,0.9,37.8,1.2,1.23
-12,手巻おにぎり 熟成紅鮭,160,"https://www.lawson.co.jp/recommend/original/detail/img/l697447.png","おにぎり,ローソン",174,4.6,1.7,34.2,1.5,1.24
-13,手巻おにぎり 半生炙りたらこ,160,"https://www.lawson.co.jp/recommend/original/detail/img/l668171.png","おにぎり,ローソン",176,4.1,1.9,35.3,0.8,1.02
-14,手巻おにぎり 明太子マヨネーズ,149,"https://www.lawson.co.jp/recommend/original/detail/img/l697436.png","おにぎり,ローソン",193,4.1,3.7,35.1,1.3,1.39
-15,手巻おにぎり 熟成辛子明太子,160,"https://www.lawson.co.jp/recommend/original/detail/img/l680794.png","おにぎり,ローソン",170,4.6,1.1,34.8,1.4,1.06
-16,手巻おにぎり シーチキンマヨネーズ,135,"https://www.lawson.co.jp/recommend/original/detail/img/l680965.png","おにぎり,ローソン",226,4.3,7.0,35.8,1.1,1.23
-17,鶏五目おにぎり,138,"https://www.lawson.co.jp/recommend/original/detail/img/l668176.png","おにぎり,ローソン",171,4.3,1.3,35.0,0.9,1.35
-18,胡麻さけおにぎり,138,"https://www.lawson.co.jp/recommend/original/detail/img/l680969.png","おにぎり,ローソン",185,7.0,2.5,33.2,0.6,1.46
-19,わかめごはんおにぎり,138,"https://www.lawson.co.jp/recommend/original/detail/img/l680970.png","おにぎり,ローソン",174,3.1,1.2,37.3,0.8,1.27
-20,北海道十勝産小豆使用 赤飯おこわおにぎり,149,"https://www.lawson.co.jp/recommend/original/detail/img/l680967.png","おにぎり,ローソン",209,4.9,1.1,43.4,3.1,0.8
-21,食物繊維が摂れる 梅しそごはんおにぎり,138,"https://www.lawson.co.jp/recommend/original/detail/img/l680968.png","おにぎり,ローソン",182,3.7,1.9,35.3,4.3,2.25
-22,食物繊維が摂れる 枝豆と塩昆布おにぎり,138,"https://www.lawson.co.jp/recommend/original/detail/img/l680757.png","おにぎり,ローソン",173,4.5,2.0,31.8,4.7,1.06
-23,たんぱく質が摂れる カオマンガイ風おにぎり,203,"https://www.lawson.co.jp/recommend/original/detail/img/l697552.png","おにぎり,ローソン",188,12.1,3.1,25.0,6.0,2.84
-24,チャーシューマヨネーズおにぎり,149,"https://www.lawson.co.jp/recommend/original/detail/img/l680966.png","おにぎり,ローソン",212,4.5,4.2,38.7,0.4,1.23
-25,北海道十勝産小豆使用 赤飯おこわおにぎり,149,"https://www.lawson.co.jp/recommend/original/detail/img/l680967.png","おにぎり,ローソン",209,4.9,1.1,43.4,3.1,0.8
-26,おにぎり2個入り(鮭・日高昆布),214,"https://www.lawson.co.jp/recommend/original/detail/img/l697553.png","おにぎり,ローソン",297,6.2,2.4,62.0,1.5,1.88
-27,おにぎりおかずセット(さけ・シーチキンマヨネーズ),387,"https://www.lawson.co.jp/recommend/original/detail/img/l680793.png","おにぎり,ローソン",525,18.8,18.2,69.9,3.0,2.33
-28,鶏ごぼう,203,"https://www.lawson.co.jp/recommend/original/detail/img/l122chubo.png","おにぎり,ローソン,まちかど厨房",223,,,,,
-29,ソーセージマヨ,203,"https://www.lawson.co.jp/recommend/original/detail/img/n27chubo.png","おにぎり,ローソン,まちかど厨房",334,,,,,
-30,博多辛子明太子,203,"https://www.lawson.co.jp/recommend/original/detail/img/n30chubo.png","おにぎり,ローソン,まちかど厨房",219,,,,,
-31,紀州南高梅,203,"https://www.lawson.co.jp/recommend/original/detail/img/n33chubo.png","おにぎり,ローソン,まちかど厨房",208,,,,,
-32,焼豚,203,"https://www.lawson.co.jp/recommend/original/detail/img/l20210817chubo0002.png","おにぎり,ローソン,まちかど厨房",253,,,,,
-33,からあげマヨ,203,"https://www.lawson.co.jp/recommend/original/detail/img/n28chubo.png","おにぎり,ローソン,まちかど厨房",325,,,,,
-34,北海道さけ,203,"https://www.lawson.co.jp/recommend/original/detail/img/n29chubo.png","おにぎり,ローソン,まちかど厨房",230,,,,,
-35,昆布,203,"https://www.lawson.co.jp/recommend/original/detail/img/n32chubo.png","おにぎり,ローソン,まちかど厨房",212,,,,,
-36,玉子焼と昆布,203,"https://www.lawson.co.jp/recommend/original/detail/img/l20221129chubo0002.png","おにぎり,ローソン,まちかど厨房",233,,,,,
-37,タルタル海老カツ,203,"https://www.lawson.co.jp/recommend/original/detail/img/l20230124chubo0001.png","おにぎり,ローソン,まちかど厨房",262,,,,,
-38,とんかつ,225,"https://www.lawson.co.jp/recommend/original/detail/img/l20211116chubo0001.png","おにぎり,ローソン,まちかど厨房",359,,,,,
-39,チキン南蛮,225,"https://www.lawson.co.jp/recommend/original/detail/img/l20210629chubo0004.png","おにぎり,ローソン,まちかど厨房",271,,,,,
-40,炭火焼チキンマヨ,279,"https://www.lawson.co.jp/recommend/original/detail/img/l123chubo.png","おにぎり,ローソン,まちかど厨房",449,,,,,
-41,さけ昆布,279,"https://www.lawson.co.jp/recommend/original/detail/img/l20220809chubo0002.png","おにぎり,ローソン,まちかど厨房",321,,,,,
+11,"手巻おにぎり 北海道産日高昆布",120,"https://www.lawson.co.jp/recommend/original/detail/img/l650861.png","おにぎり,ローソン",176,3.6,0.9,37.8,1.2,1.23
+12,"手巻おにぎり 熟成紅鮭",160,"https://www.lawson.co.jp/recommend/original/detail/img/l697447.png","おにぎり,ローソン",174,4.6,1.7,34.2,1.5,1.24
+13,"手巻おにぎり 半生炙りたらこ",160,"https://www.lawson.co.jp/recommend/original/detail/img/l668171.png","おにぎり,ローソン",176,4.1,1.9,35.3,0.8,1.02
+14,"手巻おにぎり 明太子マヨネーズ",149,"https://www.lawson.co.jp/recommend/original/detail/img/l697436.png","おにぎり,ローソン",193,4.1,3.7,35.1,1.3,1.39
+15,"手巻おにぎり 熟成辛子明太子",160,"https://www.lawson.co.jp/recommend/original/detail/img/l680794.png","おにぎり,ローソン",170,4.6,1.1,34.8,1.4,1.06
+16,"手巻おにぎり シーチキンマヨネーズ",135,"https://www.lawson.co.jp/recommend/original/detail/img/l680965.png","おにぎり,ローソン",226,4.3,7.0,35.8,1.1,1.23
+17,"鶏五目おにぎり",138,"https://www.lawson.co.jp/recommend/original/detail/img/l668176.png","おにぎり,ローソン",171,4.3,1.3,35.0,0.9,1.35
+18,"胡麻さけおにぎり",138,"https://www.lawson.co.jp/recommend/original/detail/img/l680969.png","おにぎり,ローソン",185,7.0,2.5,33.2,0.6,1.46
+19,"わかめごはんおにぎり",138,"https://www.lawson.co.jp/recommend/original/detail/img/l680970.png","おにぎり,ローソン",174,3.1,1.2,37.3,0.8,1.27
+20,"北海道十勝産小豆使用 赤飯おこわおにぎり",149,"https://www.lawson.co.jp/recommend/original/detail/img/l680967.png","おにぎり,ローソン",209,4.9,1.1,43.4,3.1,0.8
+21,"食物繊維が摂れる 梅しそごはんおにぎり",138,"https://www.lawson.co.jp/recommend/original/detail/img/l680968.png","おにぎり,ローソン",182,3.7,1.9,35.3,4.3,2.25
+22,"食物繊維が摂れる 枝豆と塩昆布おにぎり",138,"https://www.lawson.co.jp/recommend/original/detail/img/l680757.png","おにぎり,ローソン",173,4.5,2.0,31.8,4.7,1.06
+23,"たんぱく質が摂れる カオマンガイ風おにぎり",203,"https://www.lawson.co.jp/recommend/original/detail/img/l697552.png","おにぎり,ローソン",188,12.1,3.1,25.0,6.0,2.84
+24,"チャーシューマヨネーズおにぎり",149,"https://www.lawson.co.jp/recommend/original/detail/img/l680966.png","おにぎり,ローソン",212,4.5,4.2,38.7,0.4,1.23
+25,"北海道十勝産小豆使用 赤飯おこわおにぎり",149,"https://www.lawson.co.jp/recommend/original/detail/img/l680967.png","おにぎり,ローソン",209,4.9,1.1,43.4,3.1,0.8
+26,"おにぎり2個入り(鮭・日高昆布)",214,"https://www.lawson.co.jp/recommend/original/detail/img/l697553.png","おにぎり,ローソン",297,6.2,2.4,62.0,1.5,1.88
+27,"おにぎりおかずセット(さけ・シーチキンマヨネーズ)",387,"https://www.lawson.co.jp/recommend/original/detail/img/l680793.png","おにぎり,ローソン",525,18.8,18.2,69.9,3.0,2.33
+28,"鶏ごぼう",203,"https://www.lawson.co.jp/recommend/original/detail/img/l122chubo.png","おにぎり,ローソン,まちかど厨房",223,,,,,
+29,"ソーセージマヨ",203,"https://www.lawson.co.jp/recommend/original/detail/img/n27chubo.png","おにぎり,ローソン,まちかど厨房",334,,,,,
+30,"博多辛子明太子",203,"https://www.lawson.co.jp/recommend/original/detail/img/n30chubo.png","おにぎり,ローソン,まちかど厨房",219,,,,,
+31,"紀州南高梅",203,"https://www.lawson.co.jp/recommend/original/detail/img/n33chubo.png","おにぎり,ローソン,まちかど厨房",208,,,,,
+32,"焼豚",203,"https://www.lawson.co.jp/recommend/original/detail/img/l20210817chubo0002.png","おにぎり,ローソン,まちかど厨房",253,,,,,
+33,"からあげマヨ",203,"https://www.lawson.co.jp/recommend/original/detail/img/n28chubo.png","おにぎり,ローソン,まちかど厨房",325,,,,,
+34,"北海道さけ",203,"https://www.lawson.co.jp/recommend/original/detail/img/n29chubo.png","おにぎり,ローソン,まちかど厨房",230,,,,,
+35,"昆布",203,"https://www.lawson.co.jp/recommend/original/detail/img/n32chubo.png","おにぎり,ローソン,まちかど厨房",212,,,,,
+36,"玉子焼と昆布",203,"https://www.lawson.co.jp/recommend/original/detail/img/l20221129chubo0002.png","おにぎり,ローソン,まちかど厨房",233,,,,,
+37,"タルタル海老カツ",203,"https://www.lawson.co.jp/recommend/original/detail/img/l20230124chubo0001.png","おにぎり,ローソン,まちかど厨房",262,,,,,
+38,"とんかつ",225,"https://www.lawson.co.jp/recommend/original/detail/img/l20211116chubo0001.png","おにぎり,ローソン,まちかど厨房",359,,,,,
+39,"チキン南蛮",225,"https://www.lawson.co.jp/recommend/original/detail/img/l20210629chubo0004.png","おにぎり,ローソン,まちかど厨房",271,,,,,
+40,"炭火焼チキンマヨ",279,"https://www.lawson.co.jp/recommend/original/detail/img/l123chubo.png","おにぎり,ローソン,まちかど厨房",449,,,,,
+41,"さけ昆布",279,"https://www.lawson.co.jp/recommend/original/detail/img/l20220809chubo0002.png","おにぎり,ローソン,まちかど厨房",321,,,,,

--- a/db/rice.csv
+++ b/db/rice.csv
@@ -1,29 +1,29 @@
 Id,food_name,Price,Image,tag,calorie,protein,lipid,sugar,dietary_fiber,table_salt
-1,焼鮭和風幕の内,689,"https://www.lawson.co.jp/recommend/original/detail/img/l689525.png","お弁当,ローソン",524,20.9,16.2,71.7,4.1,3.53
-2,おてがるのり弁(もち麦入りご飯),322,"https://www.lawson.co.jp/recommend/original/detail/img/l696754.png","お弁当,ローソン",430,14.3,15.2,52.4,13.4,1.92
-3,おてがる鶏そぼろご飯(もち麦入りご飯),322,"https://www.lawson.co.jp/recommend/original/detail/img/l696755.png","お弁当,ローソン",323,14.5,6.2,46.8,11.0,1.98
-4,イチオシ！ミックス弁当,497,"https://www.lawson.co.jp/recommend/original/detail/img/l689523.png","お弁当,ローソン",790,25.7,32.1,96.3,6.3,3.29
-5,おてがるチャーシューご飯(もち麦入り),374,"https://www.lawson.co.jp/recommend/original/detail/img/l689524.png","お弁当,ローソン",374,14.8,10.5,49.5,10.9,3.5
-6,盛りすぎ！炒飯＆焼そば,497,"https://www.lawson.co.jp/recommend/original/detail/img/l720470.png","チルド弁当,ローソン",1266,35.7,49.8,163.4,10.8,10.44
-7,これがのり弁当,549,"https://www.lawson.co.jp/recommend/original/detail/img/l696792.png","チルド弁当,ローソン",807,28.0,33.9,94.1,6.7,3.83
-8,これがハンバーグ弁当,646,"https://www.lawson.co.jp/recommend/original/detail/img/l696791.png","チルド弁当,ローソン",763,31.5,25.5,98.5,6.5,4.33
-9,これがチキン南蛮弁当,917,"https://www.lawson.co.jp/recommend/original/detail/img/l696795.png","チルド弁当,ローソン",32.6,38.5,38.5,108.7,1.8,4.59
-10,これが鶏竜田揚げ弁当,646,"https://www.lawson.co.jp/recommend/original/detail/img/l696790.png","チルド弁当,ローソン",833,35.4,33.4,94.7,5.8,5.81
-11,これが厚切り豚焼肉弁当,689,"https://www.lawson.co.jp/recommend/original/detail/img/l696793.png","チルド弁当,ローソン",679,31.3,21.5,88.7,2.3,3.21
-12,これが豚生姜焼弁当,646,"https://www.lawson.co.jp/recommend/original/detail/img/l696789.png","チルド弁当,ローソン",747,26.1,28.6,95.5,2.0,3.3
-13,牛すき焼き弁当,689,"https://www.lawson.co.jp/recommend/original/detail/img/l696794.png","チルド弁当,ローソン",665,21.2,23.6,88.8,6.3,3.35
-14,グリル満天星お墨付き オムライス,689,"https://www.lawson.co.jp/recommend/original/detail/img/l689505.png","チルド弁当,ローソン",638,17.5,28.4,76.6,2.6,4.15
-15,欧風ビーフカレー,646,"https://www.lawson.co.jp/recommend/original/detail/img/l689520.png","チルド弁当,ローソン",570,14.8,17.5,85.9,4.9,3.18
-16,たんぱく質が摂れる照焼チキン丼,646,"https://www.lawson.co.jp/recommend/original/detail/img/l696761.png","チルド弁当,ローソン",633,50.6,25.9,44.0,10.8,2.97
-17,四川風麻婆丼,497,"https://www.lawson.co.jp/recommend/original/detail/img/l696780.png","チルド弁当,ローソン",497,503,16.4,71.3,1.4,2.39
-18,おにぎり寿司 焼さばちらし寿司,160,"https://www.lawson.co.jp/recommend/original/detail/img/l720068.png","お寿司,ローソン",170,5.8,2.2,31.2,0.9,1.74
-19,手巻寿司 ねぎとろ,192,"https://www.lawson.co.jp/recommend/original/detail/img/l680761.png","お寿司,ローソン",178,5.3,2.8,32.5,1.0,1.56
-20,手巻寿司 納豆,160,"https://www.lawson.co.jp/recommend/original/detail/img/l680956.png","お寿司,ローソン",176,5.8,1.8,33.2,1.8,1.43
-21,手巻寿司 海老マヨ,192,"https://www.lawson.co.jp/recommend/original/detail/img/l697428.png","お寿司,ローソン",184,4.3,5.0,30.2,0.5,1.68
-22,おにぎり寿司 海老寿司,225,"https://www.lawson.co.jp/recommend/original/detail/img/l720066.png","お寿司,ローソン",186,4.8,0.9,39.2,0.9,2.04
-23,おいなりさん わさび,171,"https://www.lawson.co.jp/recommend/original/detail/img/l680769.png","お寿司,ローソン",201,5.5,5.9,31,0.9,1.31
-24,いなり 3個入,235,"https://www.lawson.co.jp/recommend/original/detail/img/l697431.png","お寿司,ローソン",285,10.6,8.3,41.1,1.5,1.86
-25,助六寿司,451,"https://www.lawson.co.jp/recommend/original/detail/img/l680789.png","お寿司,ローソン",547,17.2,12.2,90.0,4.1,3.93
-26,たっぷりツナとカニカマのサラダ巻,365,"https://www.lawson.co.jp/recommend/original/detail/img/l697430.png","お寿司,ローソン",444,10.8,12.0,71.9,2.5,3.73
-27,細巻納豆 12巻,311,"https://www.lawson.co.jp/recommend/original/detail/img/l680998.png","お寿司,ローソン",342,11.5,4.2,62.6,4.0,2.7
-28,照り焼さば寿司〜九州産さば使用〜,451,"https://www.lawson.co.jp/recommend/original/detail/img/l697439.png","お寿司,ローソン",344,19.5,8.9,45.3,2.5,3.49
+1,"焼鮭和風幕の内",689,"https://www.lawson.co.jp/recommend/original/detail/img/l689525.png","お弁当,ローソン",524,20.9,16.2,71.7,4.1,3.53
+2,"おてがるのり弁(もち麦入りご飯)",322,"https://www.lawson.co.jp/recommend/original/detail/img/l696754.png","お弁当,ローソン",430,14.3,15.2,52.4,13.4,1.92
+3,"おてがる鶏そぼろご飯(もち麦入りご飯)",322,"https://www.lawson.co.jp/recommend/original/detail/img/l696755.png","お弁当,ローソン",323,14.5,6.2,46.8,11.0,1.98
+4,"イチオシ！ミックス弁当",497,"https://www.lawson.co.jp/recommend/original/detail/img/l689523.png","お弁当,ローソン",790,25.7,32.1,96.3,6.3,3.29
+5,"おてがるチャーシューご飯(もち麦入り)",374,"https://www.lawson.co.jp/recommend/original/detail/img/l689524.png","お弁当,ローソン",374,14.8,10.5,49.5,10.9,3.5
+6,"盛りすぎ！炒飯＆焼そば",497,"https://www.lawson.co.jp/recommend/original/detail/img/l720470.png","チルド弁当,ローソン",1266,35.7,49.8,163.4,10.8,10.44
+7,"これがのり弁当",549,"https://www.lawson.co.jp/recommend/original/detail/img/l696792.png","チルド弁当,ローソン",807,28.0,33.9,94.1,6.7,3.83
+8,"これがハンバーグ弁当",646,"https://www.lawson.co.jp/recommend/original/detail/img/l696791.png","チルド弁当,ローソン",763,31.5,25.5,98.5,6.5,4.33
+9,"これがチキン南蛮弁当",917,"https://www.lawson.co.jp/recommend/original/detail/img/l696795.png","チルド弁当,ローソン",32.6,38.5,38.5,108.7,1.8,4.59
+10,"これが鶏竜田揚げ弁当",646,"https://www.lawson.co.jp/recommend/original/detail/img/l696790.png","チルド弁当,ローソン",833,35.4,33.4,94.7,5.8,5.81
+11,"これが厚切り豚焼肉弁当",689,"https://www.lawson.co.jp/recommend/original/detail/img/l696793.png","チルド弁当,ローソン",679,31.3,21.5,88.7,2.3,3.21
+12,"これが豚生姜焼弁当",646,"https://www.lawson.co.jp/recommend/original/detail/img/l696789.png","チルド弁当,ローソン",747,26.1,28.6,95.5,2.0,3.3
+13,"牛すき焼き弁当",689,"https://www.lawson.co.jp/recommend/original/detail/img/l696794.png","チルド弁当,ローソン",665,21.2,23.6,88.8,6.3,3.35
+14,"グリル満天星お墨付き オムライス",689,"https://www.lawson.co.jp/recommend/original/detail/img/l689505.png","チルド弁当,ローソン",638,17.5,28.4,76.6,2.6,4.15
+15,"欧風ビーフカレー",646,"https://www.lawson.co.jp/recommend/original/detail/img/l689520.png","チルド弁当,ローソン",570,14.8,17.5,85.9,4.9,3.18
+16,"たんぱく質が摂れる照焼チキン丼",646,"https://www.lawson.co.jp/recommend/original/detail/img/l696761.png","チルド弁当,ローソン",633,50.6,25.9,44.0,10.8,2.97
+17,"四川風麻婆丼",497,"https://www.lawson.co.jp/recommend/original/detail/img/l696780.png","チルド弁当,ローソン",497,503,16.4,71.3,1.4,2.39
+18,"おにぎり寿司 焼さばちらし寿司",160,"https://www.lawson.co.jp/recommend/original/detail/img/l720068.png","お寿司,ローソン",170,5.8,2.2,31.2,0.9,1.74
+19,"手巻寿司 ねぎとろ",192,"https://www.lawson.co.jp/recommend/original/detail/img/l680761.png","お寿司,ローソン",178,5.3,2.8,32.5,1.0,1.56
+20,"手巻寿司 納豆",160,"https://www.lawson.co.jp/recommend/original/detail/img/l680956.png","お寿司,ローソン",176,5.8,1.8,33.2,1.8,1.43
+21,"手巻寿司 海老マヨ",192,"https://www.lawson.co.jp/recommend/original/detail/img/l697428.png","お寿司,ローソン",184,4.3,5.0,30.2,0.5,1.68
+22,"おにぎり寿司 海老寿司",225,"https://www.lawson.co.jp/recommend/original/detail/img/l720066.png","お寿司,ローソン",186,4.8,0.9,39.2,0.9,2.04
+23,"おいなりさん わさび",171,"https://www.lawson.co.jp/recommend/original/detail/img/l680769.png","お寿司,ローソン",201,5.5,5.9,31,0.9,1.31
+24,"いなり 3個入",235,"https://www.lawson.co.jp/recommend/original/detail/img/l697431.png","お寿司,ローソン",285,10.6,8.3,41.1,1.5,1.86
+25,"助六寿司",451,"https://www.lawson.co.jp/recommend/original/detail/img/l680789.png","お寿司,ローソン",547,17.2,12.2,90.0,4.1,3.93
+26,"たっぷりツナとカニカマのサラダ巻",365,"https://www.lawson.co.jp/recommend/original/detail/img/l697430.png","お寿司,ローソン",444,10.8,12.0,71.9,2.5,3.73
+27,"細巻納豆 12巻",311,"https://www.lawson.co.jp/recommend/original/detail/img/l680998.png","お寿司,ローソン",342,11.5,4.2,62.6,4.0,2.7
+28,"照り焼さば寿司〜九州産さば使用〜",451,"https://www.lawson.co.jp/recommend/original/detail/img/l697439.png","お寿司,ローソン",344,19.5,8.9,45.3,2.5,3.49

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,21 @@ require "open-uri"
 
 user = User.find_by(name: 'Admin', role: 2)
 
+CSV.foreach('db/rice.csv', headers: true) do |row|
+  Food.create!(
+    food_name: row['food_name'],
+    image: URI.open(row['Image']),
+    price: row['Price'],
+    calorie: row['calorie'],
+    tag_list: row['tag'].split(','),
+    protein: row['protein'],
+    lipid: row['lipid'],
+    sugar: row['sugar'],
+    dietary_fiber: row['dietary_fiber'],
+    table_salt: row['table_salt'],
+    user_id: user.id
+  )
+end
 CSV.foreach('db/onigiri.csv', headers: true) do |row|
   Food.create!(
     food_name: row['food_name'],

--- a/spec/factories/foods.rb
+++ b/spec/factories/foods.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :food do
-    food_name { Faker::Food.ingredient[0,20] }
+    food_name { Faker::Food.ingredient[0,30] }
     calorie { Faker::Number.between(from: 100, to: 1000) }
     price { Faker::Number.between(from: 100, to: 1000) }
     protein { Faker::Number.between(from: 1) }

--- a/spec/system/foods_spec.rb
+++ b/spec/system/foods_spec.rb
@@ -37,10 +37,10 @@ RSpec.describe "Foods", type: :system do
       end
     end
 
-    context '食品名が20文字以上' do
+    context '食品名が30文字以上' do
       it '食べ物の新規作成が失敗する' do
         visit new_food_path
-        fill_in 'food_food_name', with: "これは20文字以上が弾かれるかどうかを確認するテストです。"
+        fill_in 'food_food_name', with: "これは30文字以上が弾かれるかどうかを確認するテストです。30文字以上なので弾かれるはずです"
         fill_in 'food_calorie', with: 110
         fill_in 'food_price', with: 100
         fill_in 'food_protein', with: 10


### PR DESCRIPTION
## 概要

https://github.com/asakuno/debukatsu/issues/126
- groups#createでgroupsが作成できたりできなかったりする問題を修正

## 確認方法

1. local環境でエラーが起きない
2. 本番環境でエラーが起きない

## チェック

- [x] rubocopをパスした
- [x] specをパスした

## コメント

これでerror解消できないと他の原因を探すことになりそう
